### PR TITLE
Fix calling plugin autocmds

### DIFF
--- a/pythonx/ncm2_core.py
+++ b/pythonx/ncm2_core.py
@@ -81,7 +81,7 @@ class Ncm2Core(Ncm2Base):
                 glob.glob(path.join(d, 'python3/ncm2_subscope_detector/*.py'))
             self.load_subscope_detectors(dts)
 
-        self.notify('ncm2#_autocmd_plugin')
+        self.notify('ncm2#_au_plugin')
 
     def load_python(self, _, py):
         with open(py, "rb") as f:


### PR DESCRIPTION
The rename of the function (autocmds -> au) in viml wasn't covered in the python call to it.