### PR TITLE
[RFC] allow combining matchers

### DIFF
--- a/pythonx/ncm2.py
+++ b/pythonx/ncm2.py
@@ -47,17 +47,27 @@ def getLogger(name):
     logger.setLevel(get_loglevel())
     return logger
 
+def matcher_get(opt):
+    name = opt['name']
+    modname = 'ncm2_matcher.' + name
+    mod = import_module(modname)
+    m = mod.Matcher(**opt)
+    return m
+
+def matcher_opt_formalize(opt):
+    if type(opt) is str:
+        return dict(name=opt)
+    return deepcopy(opt)
 
 class Ncm2Base:
     def __init__(self, nvim):
         self.nvim = nvim
 
+    def matcher_opt_formalize(self, opt):
+        return matcher_opt_formalize(opt)
+
     def matcher_get(self, opt):
-        name = opt['name']
-        modname = 'ncm2_matcher.' + name
-        mod = import_module(modname)
-        m = mod.Matcher(**opt)
-        return m
+        return matcher_get(opt)
 
     def match_formalize(self, ctx, item):
         e = {}

--- a/pythonx/ncm2_core.py
+++ b/pythonx/ncm2_core.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import copy
 import re
 import vim
 from ncm2 import Ncm2Base, getLogger
@@ -8,6 +7,7 @@ import json
 import glob
 from os import path, environ
 from importlib import import_module
+from copy import deepcopy
 
 # don't import this module by other processes
 assert environ['NVIM_YARP_MODULE'] == 'ncm2_core'
@@ -149,7 +149,7 @@ class Ncm2Core(Ncm2Base):
         for ctx_idx, tmp_ctx in enumerate(contexts):
             for name, sr in data['sources'].items():
 
-                ctx = copy.deepcopy(tmp_ctx)
+                ctx = deepcopy(tmp_ctx)
                 ctx['early_cache'] = False
                 ctx['source'] = sr
                 ctx['matcher'] = self.matcher_opt_get(data, sr)
@@ -175,7 +175,7 @@ class Ncm2Core(Ncm2Base):
         for ctx_idx, tmp_ctx in enumerate(contexts):
             for name, sr in data['sources'].items():
 
-                ctx = copy.deepcopy(tmp_ctx)
+                ctx = deepcopy(tmp_ctx)
                 ctx['early_cache'] = False
                 ctx['source'] = sr
 
@@ -305,8 +305,8 @@ class Ncm2Core(Ncm2Base):
         self.matches_update_popup(data)
 
     def is_kw_type(self, data, sr, ctx1, ctx2):
-        ctx1 = copy.deepcopy(ctx1)
-        ctx2 = copy.deepcopy(ctx2)
+        ctx1 = deepcopy(ctx1)
+        ctx2 = deepcopy(ctx2)
 
         if not self.source_check_patterns(data, sr, ctx1):
             logger.debug('old_ctx source_check_patterns failed')
@@ -359,7 +359,7 @@ class Ncm2Core(Ncm2Base):
                     res = sd.detect(lnum, ccol, scope_src)
                     if not res:
                         continue
-                    sub = copy.deepcopy(ctx)
+                    sub = deepcopy(ctx)
                     sub.update(res)
 
                     # adjust offset to global based and add the new context
@@ -495,7 +495,7 @@ class Ncm2Core(Ncm2Base):
                     logger.warn('%s invalid startccol %s', name, sccol)
                     continue
 
-                smat = copy.deepcopy(cache['matches'])
+                smat = deepcopy(cache['matches'])
                 sctx = cache['context']
                 smat = self.matches_filter(data, sr, sctx, sccol, smat)
                 cache['filtered_matches'] = smat
@@ -563,11 +563,6 @@ class Ncm2Core(Ncm2Base):
     def get_sources_for_popup(self, data, names):
         return names
 
-    def matcher_opt_formalize(self, opt):
-        if type(opt) is str:
-            return dict(name=opt)
-        return copy.deepcopy(opt)
-
     def matcher_opt_get(self, data, sr):
         gmopt = self.matcher_opt_formalize(data['matcher'])
         smopt = {}
@@ -579,7 +574,7 @@ class Ncm2Core(Ncm2Base):
     def sorter_opt_formalize(self, opt):
         if type(opt) is str:
             return dict(name=opt)
-        return copy.deepcopy(opt)
+        return deepcopy(opt)
 
     def sorter_opt_get(self, data, sr):
         gsopt = self.sorter_opt_formalize(data['sorter'])
@@ -597,7 +592,7 @@ class Ncm2Core(Ncm2Base):
         return m
 
     def filter_opt_formalize(self, opts):
-        opts = copy.deepcopy(opts)
+        opts = deepcopy(opts)
         if type(opts) is not list:
             opts = [opts]
         ret = []

--- a/pythonx/ncm2_matcher/combine.py
+++ b/pythonx/ncm2_matcher/combine.py
@@ -1,0 +1,18 @@
+from ncm2 import matcher_get, matcher_opt_formalize
+
+def Matcher(**kargs):
+    opts = kargs['matchers']
+    matchers = []
+
+    for opt in opts:
+        opt = matcher_opt_formalize(opt)
+        matcher = matcher_get(opt)
+        matchers.append(matcher)
+
+    def match(b, m):
+        for matcher in matchers:
+            if matcher(b, m):
+                return True
+        return False
+
+    return match


### PR DESCRIPTION
The key is 
```vim
            \ 'matcher': {'name': 'combine',
            \           'matchers': [
            \               {'name': 'abbrfuzzy', 'key': 'menu'},
            \               {'name': 'prefix', 'key': 'word'},
            \           ]},
```

Demo:

![rec](https://user-images.githubusercontent.com/4538941/42723200-44a1b066-878c-11e8-8bce-cf5017356935.gif)

test files from https://github.com/ncm2/ncm2/issues/22#issue-341218712

minimal vimrc:

```vim
execute 'source ' . $WORKSPACE_DIR . '/plug.vim'

call plug#begin($WORKSPACE_DIR)

Plug 'roxma/nvim-yarp'
Plug 'ncm2/ncm2'
Plug 'lervag/vimtex'
Plug 'ncm2/ncm2-match-highlight'

call plug#end()

au BufEnter * call ncm2#enable_for_buffer()
au User Ncm2Plugin call ncm2#register_source({
            \ 'name' : 'vimtex',
            \ 'priority': 1,
            \ 'subscope_enable': 1,
            \ 'complete_length': 1,
            \ 'scope': ['tex'],
            \ 'matcher': {'name': 'combine',
            \           'matchers': [
            \               {'name': 'abbrfuzzy', 'key': 'menu'},
            \               {'name': 'prefix', 'key': 'word'},
            \           ]},
            \ 'mark': 'tex',
            \ 'word_pattern': '\w+',
            \ 'complete_pattern': g:vimtex#re#ncm,
            \ 'on_complete': ['ncm2#on_complete#omni', 'vimtex#complete#omnifunc'],
            \ })
set completeopt=noinsert,menuone,noselect

set noshowmode
```

Comments? @clason @balta2ar