### PR TITLE
substr_fuzzy_match() check abbrs[] size at first

### DIFF
--- a/pythonx/ncm2_matcher/substrfuzzy.py
+++ b/pythonx/ncm2_matcher/substrfuzzy.py
@@ -51,7 +51,10 @@ def abbrs_ge(abbrs, ge):
 
 def substr_fuzzy_match(b, s, abbrs, chcmp):
     end = len(s)
-    start = abbrs[0]
+    if len(abbrs):
+        start = abbrs[0]
+    else:
+        return None
     while end > start:
         pos, l = max_substr_match(b, s, [start, end], chcmp)
         if not l:


### PR DESCRIPTION
check abbrs[] size at first in func substr_fuzzy_match().

fix https://github.com/ncm2/ncm2-pyclang/issues/14