### PR TITLE
Fixed 3 issues of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/pythonx/ncm2_matcher/abbrfuzzy.py
+++ b/pythonx/ncm2_matcher/abbrfuzzy.py
@@ -1,8 +1,8 @@
 import re
 
-chcmp_smartcase = lambda a,b: a==b if a.isupper() else a==b.lower()
-chcmp_case = lambda a,b: a==b
-chcmp_icase = lambda a,b: a.lower()==b.lower()
+chcmp_smartcase = lambda a,b: a == b if a.isupper() else a == b.lower()
+chcmp_case = lambda a,b: a == b
+chcmp_icase = lambda a,b: a.lower() == b.lower()
 
 def get_abbrev(s):
     res = []


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.