### PR TITLE
Built-in LSP support

### DIFF
--- a/autoload/ncm2/on_complete.vim
+++ b/autoload/ncm2/on_complete.vim
@@ -68,3 +68,8 @@ func! s:call_omnifunc(omnifunc, ...) abort
         endif
     endtry
 endfunc
+
+func! ncm2#on_complete#lsp(context)
+    lua ncm2 = require("ncm2")
+    call v:lua.ncm2.on_complete_lsp(a:context)
+endfunc

--- a/lua/ncm2/init.lua
+++ b/lua/ncm2/init.lua
@@ -1,0 +1,55 @@
+local function on_completion_result(context, err, _, result)
+    if err or not result then
+        return
+    end
+
+    local matches = vim.lsp.util.text_document_completion_list_to_complete_items(result)
+    vim.api.nvim_call_function('ncm2#complete', {context, context.startccol, matches})
+end
+
+local function on_complete_lsp(context)
+    vim.lsp.buf_request(
+        context.bufnr,
+        'textDocument/completion',
+        vim.lsp.util.make_position_params(),
+        function(err, _, result)
+            on_completion_result(context, err, _, result)
+        end
+    )
+end
+
+local function escape(chars)
+    local result = {}
+    for i = 1, #chars do
+        result[i] = vim.pesc(chars[i]):gsub('%%', '\\')
+    end
+    return result
+end
+
+local function register_lsp_source(client, result)
+    if not client.server_capabilities.completionProvider then
+        return
+    end
+
+    local bufnr = vim.api.nvim_get_current_buf()
+    local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
+    local trigger_chars = client
+        .server_capabilities
+        .completionProvider
+        .triggerCharacters
+        or {}
+    local source = {
+        name = 'nlc_' .. filetype,
+        priority = 9,
+        scope = {filetype},
+        mark = 'nlc',
+        complete_pattern = escape(trigger_chars),
+        on_complete = 'ncm2#on_complete#lsp'
+    }
+    vim.api.nvim_call_function('ncm2#register_source', {source})
+end
+
+return {
+    on_complete_lsp = on_complete_lsp,
+    register_lsp_source = register_lsp_source
+}


### PR DESCRIPTION
Hi, @roxma 
Here are some functions to make integration with built-in LSP easer.

As for now, LSP doesn't provide autocmd to automatically register ncm2 source on initialization, so I decided to provide `ncm2.register_lsp_source` lua function which could be passed as `on_init` callback (or called inside it). 

Tested on rust and python language servers.

Scenario 1. Automatic `ncm2#register_source` via `on_init` callback
```
lua << EOF
local nvim_lsp = require('nvim_lsp')
local ncm2 = require('ncm2')
nvim_lsp.pyls.setup{on_init = ncm2.register_lsp_source}
EOF
```

Scenario 2. Manual `ncm2#register_source`
Example LSP setup:
```
lua << EOF
local nvim_lsp = require('nvim_lsp')
nvim_lsp.rls.setup{}
EOF
```
NCM2 setup:
```
au User Ncm2Plugin call ncm2#register_source({
    \ 'name' : 'Rust',
    \ 'priority': 9,
    \ 'scope': ['rust'],
    \ 'mark': 'RLS',
    \ 'complete_pattern': ['\.', ':'],
    \ 'on_complete': 'ncm2#on_complete#lsp',
    \ })
```
`'ncm2#on_complete#lsp` will call built-in language client assosiated with current buffer.


Minimal working vimrc:
```
call plug#begin('~/.config/nvim/plugged')
Plug 'roxma/nvim-yarp'
" my fork:
Plug 'Anexen/ncm2', { 'branch': 'feature/built-in-lsp' }  
Plug 'neovim/nvim-lsp'
call plug#end()

set completeopt=menuone,noinsert,noselect
set pumheight=20
set shortmess+=c
inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "<Tab>"
inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"

lua << EOF
local nvim_lsp = require('nvim_lsp')
local ncm2 = require('ncm2')
nvim_lsp.rls.setup{on_init = ncm2.register_lsp_source}
EOF

autocmd BufEnter * call ncm2#enable_for_buffer()
```

Related issue: https://github.com/ncm2/ncm2/issues/93