### PR TITLE
Escape trailing slashes on patterns

### DIFF
--- a/pythonx/ncm2_core.py
+++ b/pythonx/ncm2_core.py
@@ -529,7 +529,13 @@ class Ncm2Core(Ncm2Base):
 
             # We need to escape any trailing backslashes, or it looks like we're trying to escape
             # the end of a pattern
-            if pat.endswith('\\'):
+            pat_trailing_backslashes = 0
+            for c in reversed(pat):
+              if c != '\\':
+                break
+
+              pat_trailing_backslashes += 1
+            if pat_trailing_backslashes % 2 != 0:
               pat = pat + '\\'
 
             matched = re.search(pat, typed)

--- a/pythonx/ncm2_core.py
+++ b/pythonx/ncm2_core.py
@@ -527,6 +527,11 @@ class Ncm2Core(Ncm2Base):
             if not pat.startswith("^"):
                 pat = '.*' + pat
 
+            # We need to escape any trailing backslashes, or it looks like we're trying to escape
+            # the end of a pattern
+            if pat.endswith('\\'):
+              pat = pat + '\\'
+
             matched = re.search(pat, typed)
             if matched and matched.end() >= len(typed) - len(ctx['base']):
                 ctx['match_end'] = matched.end()


### PR DESCRIPTION
Some matcher patterns from LSP servers (e.g. https://texlab.netlify.com/) end with `\`. A trailing unescaped `\` in a pattern causes an error with Python's regex matcher.

This patch checks if a match pattern has an odd number of trailing backslashes and, if so, adds another to escape the trailing slash.

To test the bug this fixes, try using `texlab` with the Neovim native LSP, with and without this patch. Without the patch, `ncm2` will crash. With the patch, you should get completions as expected.