### PR TITLE
on_warmup: Respect blacklist_for_buffer

### DIFF
--- a/pythonx/ncm2_core.py
+++ b/pythonx/ncm2_core.py
@@ -246,8 +246,7 @@ class Ncm2Core(Ncm2Base):
         warmups = []
 
         sources = self.get_filtered_sources(data, names)
-
-        names = names or list(sources.keys())
+        names = list(sources.keys())
 
         contexts = self.detect_subscopes(data)
         for ctx_idx, tmp_ctx in enumerate(contexts):


### PR DESCRIPTION
I've been running into an issue where if I add the following to my vimrc
(or more accurately, my ftplugin/$filename.vim):

    call ncm2#blacklist_for_buffer(['bufpath', 'rootpath', 'cwdpath'])

I start seeing one of the following errors upon startup when opening a
file of that type.

    [ncm2_core@yarp] KeyError: rootpath
    [ncm2_core@yarp] KeyError: cwdpath
    [ncm2_core@yarp] KeyError: bufpath

Per `:messages`,

    [ncm2_core@yarp] Traceback (most recent call last):
    [ncm2_core@yarp]   File "[...]/.config/nvim/plugged/nvim-yarp/pythonx/yarp.py", line 34, in on_notification
    [ncm2_core@yarp]     getattr(module_obj, method)(*args)
    [ncm2_core@yarp]   File "[...]/.config/nvim/plugged/ncm2/pythonx/ncm2_core.py", line 255, in on_warmup
    [ncm2_core@yarp]     sr = sources[name]
    [ncm2_core@yarp] KeyError: 'bufpath'

This was strange because get_filtered_sources specifically removes
blacklisted sources from the list of names it considers.

Turns out that was not enough because `on_warmup` prefers to use the
provided names, not the filtered names:

    names = names or [..]

This PR attempts to resolve this issue by switching `on_warmup` to using
the list of names generated from the filtered sources.

Another option is for us to ignore failures in `sources[name]` if this
is undesirable.
