### PR TITLE
Fix completion-handler signature for neovim 0.5.1+

### DIFF
--- a/lua/ncm2/init.lua
+++ b/lua/ncm2/init.lua
@@ -12,7 +12,7 @@ local function on_complete_lsp(context)
         context.bufnr,
         'textDocument/completion',
         vim.lsp.util.make_position_params(),
-        function(err, _, result)
+        function(err, result, _)
             on_completion_result(context, err, _, result)
         end
     )


### PR DESCRIPTION
The signature got changed in 0.5.1[1] which caused ncm2's handler to
fail with errors such as

    attempt to index local 'item' (a number value)

because the third argument of the handler function isn't the LSP
response, but additional state.

Fixes #200

[1] https://github.com/neovim/neovim/commit/cd8f6c5fb7858d8981fdfb2067bddb3eb86c13d0

cc @openlyDarwin @roxma